### PR TITLE
added docstrings to helper functions

### DIFF
--- a/neonx/geoff.py
+++ b/neonx/geoff.py
@@ -10,6 +10,14 @@ __all__ = ['get_geoff']
 
 
 def get_node(node_name, properties, encoder):
+    """converts a NetworkX node into a Geoff string.
+
+    :param node_name: the ID of a NetworkX node
+    :param properties: a dictionary of node attributes
+    :param encoder: an instance of a JSON encoder (e.g.
+        `json.JSONEncoder`)
+    :rtype: A Geoff string
+    """
     if properties:
         return '({0} {1})'.format(node_name,
                                   encoder.encode(properties))
@@ -18,6 +26,17 @@ def get_node(node_name, properties, encoder):
 
 
 def get_edge(from_node, to_node, properties, edge_relationship_name, encoder):
+    """converts a NetworkX edge into a Geoff string.
+
+    :param from_node: the ID of a NetworkX source node
+    :param to_node: the ID of a NetworkX target node
+    :param properties: a dictionary of edge attributes
+    :param edge_relationship_name: string that describes the
+        relationship between the two nodes
+    :param encoder: an instance of a JSON encoder (e.g.
+        `json.JSONEncoder`)
+    :rtype: A Geoff string
+    """
     edge_string = None
     if properties:
         args = [from_node, edge_relationship_name,

--- a/neonx/neo.py
+++ b/neonx/neo.py
@@ -121,7 +121,7 @@ def get_server_urls(server_url):
     """connects to the server with a GET request and returns its answer
     (e.g. a number of URLs of REST endpoints, the server version etc.)
     as a dictionary.
-    
+
     :param server_url: the URL of the Neo4j server
     :rtype: a dictionary of parameters of the Neo4j server
     """

--- a/neonx/neo.py
+++ b/neonx/neo.py
@@ -14,6 +14,12 @@ HEADERS = {'content-type': JSON_CONTENT_TYPE}
 
 
 def get_node(node_id, properties):
+    """reformats a NetworkX node for `generate_data()`.
+
+    :param node_id: the index of a NetworkX node
+    :param properties: a dictionary of node attributes
+    :rtype: a dictionary representing a Neo4j POST request
+    """
     return {"method": "POST",
             "to": "/node",
             "id": node_id,
@@ -21,6 +27,15 @@ def get_node(node_id, properties):
 
 
 def get_relationship(from_id, to_id, rel_name, properties):
+    """reformats a NetworkX edge for `generate_data()`.
+
+    :param from_id: the ID of a NetworkX source node
+    :param to_id: the ID of a NetworkX target node
+    :param rel_name: string that describes the relationship between the
+        two nodes
+    :param properties: a dictionary of edge attributes
+    :rtype: a dictionary representing a Neo4j POST request
+    """
     body = {"to": "{{{0}}}".format(to_id), "type": rel_name,
             "data": properties}
 
@@ -30,12 +45,30 @@ def get_relationship(from_id, to_id, rel_name, properties):
 
 
 def get_label(i, label):
+    """adds a label to the given (Neo4j) node.
+
+    :param i: the index of a NetworkX node
+    :param label: the label to be added to the node
+    :rtype: a dictionary representing a Neo4j POST request
+    """
     return {"method": "POST",
             "to": "{{{0}}}/labels".format(i),
             "body": label}
 
 
 def generate_data(graph, edge_rel_name, label, encoder):
+    """converts a NetworkX graph into a format that can be uploaded to
+    Neo4j using a single HTTP POST request.
+
+    :rtype: a JSON encoded string for `Neo4j batch operations \
+    <http://docs.neo4j.org/chunked/stable/rest-api-batch-ops.html>_`.
+
+    :param graph: A NetworkX Graph or a DiGraph
+    :param edge_rel_name: string that describes the relationship between
+        the two nodes
+    :param label: an optional label to be added to all nodes
+    :param encoder: a JSONEncoder object
+    """
     is_digraph = isinstance(graph, nx.DiGraph)
     entities = []
     nodes = {}
@@ -63,6 +96,14 @@ def generate_data(graph, edge_rel_name, label, encoder):
 
 
 def check_exception(result):
+    """checks, if the preceding HTTP request was accepted by the Neo4j
+    server.
+
+    :param result: a `Response \
+<http://docs.python-requests.org/en/latest/api/#requests.Response>`_
+        instance.
+    :rtype: an Exception or None
+    """
     if result.status_code == 200:
         return
 
@@ -77,6 +118,13 @@ def check_exception(result):
 
 
 def get_server_urls(server_url):
+    """connects to the server with a GET request and returns its answer
+    (e.g. a number of URLs of REST endpoints, the server version etc.)
+    as a dictionary.
+    
+    :param server_url: the URL of the Neo4j server
+    :rtype: a dictionary of parameters of the Neo4j server
+    """
     result = requests.get(server_url)
     check_exception(result)
     return result.json()


### PR DESCRIPTION
Dear Rohit,

I added some additional docstrings to your code. We should not need unit tests for this, but when I tried running them anyway, this happened:

``` python
~/repos/neonx $ python setup.py test
running test
running egg_info
writing requirements to neonx.egg-info/requires.txt
writing neonx.egg-info/PKG-INFO
writing top-level names to neonx.egg-info/top_level.txt
writing dependency_links to neonx.egg-info/dependency_links.txt
reading manifest file 'neonx.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'neonx.egg-info/SOURCES.txt'
running build_ext
Traceback (most recent call last):
  File "setup.py", line 49, in <module>
    test_suite='tests',
  File "/home/arne/anaconda/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/home/arne/anaconda/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/home/arne/anaconda/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/arne/anaconda/lib/python2.7/site-packages/setuptools/command/test.py", line 138, in run
    self.with_project_on_sys_path(self.run_tests)
  File "/home/arne/anaconda/lib/python2.7/site-packages/setuptools/command/test.py", line 118, in with_project_on_sys_path
    func()
  File "/home/arne/anaconda/lib/python2.7/site-packages/setuptools/command/test.py", line 164, in run_tests
    testLoader = cks
  File "/home/arne/anaconda/lib/python2.7/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/home/arne/anaconda/lib/python2.7/unittest/main.py", line 149, in parseArgs
    self.createTests()
  File "/home/arne/anaconda/lib/python2.7/unittest/main.py", line 158, in createTests
    self.module)
  File "/home/arne/anaconda/lib/python2.7/unittest/loader.py", line 130, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/home/arne/anaconda/lib/python2.7/unittest/loader.py", line 103, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/arne/anaconda/lib/python2.7/site-packages/setuptools/command/test.py", line 35, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/home/arne/anaconda/lib/python2.7/unittest/loader.py", line 100, in loadTestsFromName
    parent, obj = obj, getattr(obj, part)
AttributeError: 'module' object has no attribute 'test_neo'
```

Any ideas on this?

Kind regards,
Arne
