### PR TITLE
Modified write_to_neo (and generate_data) to allow one to specific an edge property to use as the relation name

### DIFF
--- a/include/python2.7
+++ b/include/python2.7
@@ -1,0 +1,1 @@
+//anaconda/include/python2.7

--- a/tests/test_neo.py
+++ b/tests/test_neo.py
@@ -169,5 +169,86 @@ class TestGetGraph(unittest.TestCase):
         self.assertEqual(graph.edge[1][2]['date'], "2011-01-01")
 
 
+class TestEdgeLabels(unittest.TestCase):
+    def setUp(self):
+        self.encoder = json.JSONEncoder()
+        self.graph = nx.Graph()
+        self.graph.add_edge(0, 1, label='KNOWS')
+        self.graph.add_edge(1, 2, label='LIKES')
+        self.graph.add_edge(2, 0, joe='BLOGGS')
+
+    def test_no_rel_name_or_key(self):
+        """
+        `write_to_neo` should raise a ValueError if both `edge_rel_name`
+        and `edge_rel_key` are missing.
+
+        `generate_data` should raise a ValueError if both `edge_rel_name`
+        and `edge_rel_key` are missing.
+        """
+
+        f = lambda: write_to_neo("http://localhost:7474/db/data/", self.graph)
+        self.assertRaises(ValueError, f)
+
+        f = lambda: generate_data(self.graph, encoder=self.encoder)
+        self.assertRaises(ValueError, f)
+
+    def test_edge_rel_defaults(self):
+        """
+        If `edge_rel_key` is not found in an edge's properties, then
+        `generate_data` should attempt to default to the value of
+        `edge_rel_name`. If `edge_rel_name` is not provided, should raise
+        a ValueError.
+        """
+
+        # `self.graph` contains an edge without the `label` property.
+        try:
+            generate_data(self.graph, edge_rel_name='LINKED_TO',
+                          edge_rel_key='label', encoder=self.encoder)
+        except ValueError:
+            self.fail()
+
+        # No `edge_rel_name` to which to default.
+        f = lambda: generate_data(self.graph, edge_rel_key='label',
+                                  encoder=self.encoder)
+        self.assertRaises(ValueError, f)
+
+    def test_edge_rel_key(self):
+        """
+        If `edge_rel_key` is provided, then it should be used to generate
+        relation names.
+        """
+
+        edge_rel_name = 'LINKED_TO'
+        edge_rel_key = 'label'
+        data = json.loads(generate_data(self.graph,
+                                        edge_rel_name=edge_rel_name,
+                                        edge_rel_key=edge_rel_key,
+                                        encoder=self.encoder))
+
+        for datum in data:
+            if datum['to'].endswith('relationships'):
+                src = int(datum['to'].split('/')[0][1:-1])
+                tgt = int(datum['body']['to'][1:-1])
+                label = datum['body']['type']
+                props = self.graph.edge[src][tgt]
+
+                # If `edge_rel_key` was in the edge property, it should have
+                #  been used as the relation name.
+                if edge_rel_key in props:
+                    self.assertEqual(props[edge_rel_key], label)
+
+                # Otherwise, `edge_rel_name` should have been used.
+                else:
+                    self.assertEqual(edge_rel_name, label)
+
+        # Writing the resulting requests should not raise any exceptions.
+        try:
+            write_to_neo("http://localhost:7474/db/data/", self.graph,
+                         edge_rel_name=edge_rel_name,
+                         edge_rel_key=edge_rel_key)
+        except:
+            self.fail('Could not write graph to neo4j')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If `edge_rel_key` is not provided, then defaults to `edge_rel_name`. This involved making some existing parameters optional, in order to maintain the call signature and not impact compatibility.

For example:

``` python
from neonx import write_to_neo

import networkx as nx
G = nx.Graph()
G.add_nodes_from([1, 2, 3])
G.add_edge(1, 2, label='KNOWS')
G.add_edge(2, 3)

results = write_to_neo("http://localhost:7474/db/data/", G, 'LINKS_TO', 'Node', edge_rel_key='label')
```
